### PR TITLE
Safe area back

### DIFF
--- a/Flaredown/FDMainViewController.m
+++ b/Flaredown/FDMainViewController.m
@@ -29,7 +29,6 @@
   
     //Style page
     _alarmButton.layer.cornerRadius = _alarmButton.frame.size.width/2;
-//    [FDStyle addShadowToView:_alarmButton];
 }
 
 - (void)viewDidAppear:(BOOL)animated {

--- a/Flaredown/FDMainViewController.m
+++ b/Flaredown/FDMainViewController.m
@@ -23,9 +23,7 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     self.webView.delegate = self;
-    self.webView.clipsToBounds = false;
     self.webView.scrollView.bounces = false;
-    self.webView.scrollView.clipsToBounds = false;
   
     //Style page
     _alarmButton.layer.cornerRadius = _alarmButton.frame.size.width/2;

--- a/Flaredown/FDMainViewController.m
+++ b/Flaredown/FDMainViewController.m
@@ -29,9 +29,6 @@
   
     //Style page
     _alarmButton.layer.cornerRadius = _alarmButton.frame.size.width/2;
-}
-
-- (void)viewDidAppear:(BOOL)animated {
     
     //Setup progress
     self.hud = [[MBProgressHUD alloc] initWithView:self.view];


### PR DESCRIPTION
- Maybe the transparent safe area was not such a good idea, using the app it felt weird so we changed back and the safe area at the top and bottom are not transparent anymore;
- Code inside viewDidAppear is being moved to viewDidLoad because that code only needs to be called once, when the app/view loads, and viewDidAppear is called multiple times the the app lifecycle;
- Removed commented code.